### PR TITLE
Fix shelve key error

### DIFF
--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -101,18 +101,16 @@ class PokemonGoBot(Datastore):
 
         self.capture_locked = False  # lock catching while moving to VIP pokemon
 
-        #client_id_file_path = os.path.join(_base_dir, 'data', 'mqtt_client_id')
-        #saved_info = shelve.open(client_id_file_path)
-        #if saved_info.has_key('client_id'):
-        #    self.config.client_id = saved_info['client_id']
-        #else:
-        #    client_uuid = uuid.uuid4()
-        #    self.config.client_id = str(client_uuid)
-        #    saved_info['client_id'] = self.config.client_id
-        #saved_info.close()
-        # There's issue report, just disable this part.
-        client_uuid = uuid.uuid4()
-        self.config.client_id = str(client_uuid)
+        client_id_file_path = os.path.join(_base_dir, 'data', 'mqtt_client_id')
+        saved_info = shelve.open(client_id_file_path)
+        key = 'client_id'.encode('utf-8')
+        if key in saved_info:
+            self.config.client_id = saved_info[key]
+        else:
+            self.config.client_id = str(uuid.uuid4())
+            saved_info[key] = self.config.client_id
+        saved_info.close()
+        
     def start(self):
         self._setup_event_system()
         self._setup_logging()


### PR DESCRIPTION
- removed .has_key (depreciated) and replaced with "in"
- change key to utf-8

closes  #4741

For a number of reasons, I think we should use shelve. 