### PR TITLE
PolylineWalker no longer overrides super .step() method

### DIFF
--- a/pokemongo_bot/cell_workers/follow_cluster.py
+++ b/pokemongo_bot/cell_workers/follow_cluster.py
@@ -62,8 +62,8 @@ class FollowCluster(BaseTask):
                 )
                 
                 self.is_at_destination = False		
- -              if step_walker.step():		
- -                  self.is_at_destination = True
+                if step_walker.step():
+                    self.is_at_destination = True
             elif not self.announced:
                 self.emit_event(
                     'arrived_at_cluster',

--- a/pokemongo_bot/cell_workers/follow_spiral.py
+++ b/pokemongo_bot/cell_workers/follow_spiral.py
@@ -67,7 +67,7 @@ class FollowSpiral(BaseTask):
         return coords
 
     def work(self):
-        last_lat, last_lng, last_alt = self.bot.get_position()
+        last_lat, last_lng, last_alt = self.bot.position()
 
         point = self.points[self.ptr]
 

--- a/pokemongo_bot/test/polyline_generator_test.py
+++ b/pokemongo_bot/test/polyline_generator_test.py
@@ -68,18 +68,18 @@ class PolylineTestCase(unittest.TestCase):
 
     @patch('time.time', mock_start)
     def test_pos_and_alt_at_time_mock_start(self):
-        self.assertEquals(self.polyline.get_pos(), (round(ex_orig[0], 5), round(ex_orig[1], 5)))
-        self.assertEquals(self.polyline.get_alt(), round(self.polyline.polyline_elevations[0], 2))
+        self.assertEquals(self.polyline.get_pos(), ex_orig)
+        self.assertEquals(self.polyline.get_alt(), self.polyline.polyline_elevations[0])
 
     @patch('time.time', mock_seven_sec)
     def test_pos_and_alt_at_time_mock_seven_sec(self):
-        self.assertEquals(self.polyline.get_pos(), (47.17049, 8.51669))
-        self.assertAlmostEqual(self.polyline.get_alt(), self.polyline.polyline_elevations[6], places=2)
+        self.assertEquals(self.polyline.get_pos(), (47.17048868132221, 8.516689560440737))
+        self.assertAlmostEqual(self.polyline.get_alt(), self.polyline.polyline_elevations[6], places=1)
 
     @patch('time.time', mock_end)
     def test_pos_and_alt_at_time_mock_end(self):
         self.assertEquals(self.polyline.get_pos(), ex_dest)
-        self.assertAlmostEqual(self.polyline.get_alt(), self.polyline.polyline_elevations[-1], places=2)
+        self.assertEquals(self.polyline.get_alt(), self.polyline.polyline_elevations[-1])
 
     def test_nr_of_elevations_returned(self):
         total_seconds = self.polyline.get_total_distance(self.polyline.points)/self.polyline.speed
@@ -107,8 +107,8 @@ class PolylineTestCase(unittest.TestCase):
 
         @patch('time.time', mock_seven_sec)
         def position_check():
-            self.assertEquals(self.polyline.get_pos(), (round(ex_orig[0], 5), round(ex_orig[1], 5)))
-            self.assertEquals(self.polyline.get_alt(), round(self.polyline.polyline_elevations[0], 2))
+            self.assertEquals(self.polyline.get_pos(), ex_orig)
+            self.assertEquals(self.polyline.get_alt(), self.polyline.polyline_elevations[0])
         position_check()
 
     def test_unpause(self):
@@ -127,8 +127,8 @@ class PolylineTestCase(unittest.TestCase):
 
         @patch('time.time', mock_seven_sec)
         def position_check():
-            self.assertEquals(self.polyline.get_pos(), (round(ex_orig[0], 5), round(ex_orig[1], 5)))
-            self.assertEquals(self.polyline.get_alt(), round(self.polyline.polyline_elevations[0], 2))
+            self.assertEquals(self.polyline.get_pos(), ex_orig)
+            self.assertEquals(self.polyline.get_alt(), self.polyline.polyline_elevations[0])
         position_check()
 
     def test_total_distance(self):

--- a/pokemongo_bot/walkers/polyline_generator.py
+++ b/pokemongo_bot/walkers/polyline_generator.py
@@ -143,9 +143,9 @@ class Polyline(object):
         seconds_passed = abs(time_passed - self._timestamp - self._paused_total)
         elevation_index = int(seconds_passed*conversion_factor)
         try:
-            return round(self.polyline_elevations[elevation_index], 2)
+            return self.polyline_elevations[elevation_index]
         except IndexError:
-            return round(self.polyline_elevations[-1], 2)
+            return self.polyline_elevations[-1]
 
     def get_pos(self):
         walked_distance = 0.0
@@ -189,7 +189,7 @@ class Polyline(object):
             # this ensures ~3-50cm ofset from the geometrical point calculated
             lat = o[0]+ (d[0] -o[0]) * percentage
             lon = o[1]+ (d[1] -o[1]) * percentage
-            return [(round(lat, 5), round(lon, 5))]
+            return [(lat, lon)]
 
     def get_total_distance(self, points):
         return ceil(sum([haversine.haversine(*x)*1000 for x in self.walk_steps(points)]))

--- a/pokemongo_bot/walkers/polyline_generator.py
+++ b/pokemongo_bot/walkers/polyline_generator.py
@@ -21,8 +21,9 @@ class PolylineObjectHandler:
         Google API has limits, so we can't generate new Polyline at every tick...
         '''
 
-        # _cache might be None...
-        is_old_cache = lambda : tuple(origin) != PolylineObjectHandler._cache.get_last_pos()
+        # Absolute offset between bot origin and PolyLine get_last_pos() (in meters)
+        abs_offset = abs(haversine.haversine(tuple(origin), PolylineObjectHandler._cache.get_last_pos())*1000)
+        is_old_cache = lambda : abs_offset < 8 # Consider cache old if we identified an offset more then 8 m
         new_dest_set = lambda : tuple(destination) != PolylineObjectHandler._cache.destination
 
         if PolylineObjectHandler._run and (not is_old_cache()):

--- a/pokemongo_bot/walkers/polyline_walker.py
+++ b/pokemongo_bot/walkers/polyline_walker.py
@@ -1,49 +1,18 @@
-# -*- coding: utf-8 -*-
-
-from random import uniform
-from pokemongo_bot.human_behaviour import sleep
 from pokemongo_bot.walkers.step_walker import StepWalker
 from polyline_generator import PolylineObjectHandler
-from pokemongo_bot.cell_workers.utils import distance
-from pokemongo_bot.constants import Constants
+
 
 class PolylineWalker(StepWalker):
 
     def __init__(self, bot, dest_lat, dest_lng):
-        super(PolylineWalker, self).__init__(bot, dest_lat, dest_lng)
-
-        self.actual_pos = tuple(self.api.get_position()[:2])
-
-        self.dist = distance(
-            self.bot.position[0],
-            self.bot.position[1],
-            dest_lat,
-            dest_lng
-        )
-
-    def step(self):
-        self.polyline_walker = PolylineObjectHandler.cached_polyline(self.actual_pos,
-                                        (self.destLat, self.destLng), self.speed)
-
-        if self.dist < 10: # 10m, add config? set it at constants?
-            return True
-
-        self.polyline_walker.unpause()
-        sleep(1)
-        self.polyline_walker.pause()
-        
-        cLat, cLng = self.polyline_walker.get_pos()
-        cAlt = self.polyline_walker.get_alt()
-    
-        step_walker = StepWalker(
-            self.bot,
-            cLat,
-            cLng,
-            cAlt
-        )
-        
-        self.actual_pos = (cLat, cLng) # might be a case this instance is reused in the future...
-
-        self.bot.heartbeat()
-        return False
-
+        self.bot = bot
+        self.speed = self.bot.config.walk_min
+        self.dest_lat, self.dest_lng = dest_lat, dest_lng
+        self.actual_pos = tuple(self.bot.position()[:2])
+        self.polyline = PolylineObjectHandler.cached_polyline(self.actual_pos,
+                                                              (self.dest_lat, self.dest_lng),
+                                                              self.speed)
+        self.pol_lat, self.pol_lon = self.polyline.get_pos()
+        self.pol_alt = self.polyline.get_alt()
+        super(PolylineWalker, self).__init__(self.bot, self.pol_lat, self.pol_lon,
+                                             self.pol_alt, fixed_speed=True)

--- a/pokemongo_bot/walkers/step_walker.py
+++ b/pokemongo_bot/walkers/step_walker.py
@@ -4,9 +4,10 @@ from random import uniform
 from pokemongo_bot.cell_workers.utils import distance
 from pokemongo_bot.human_behaviour import random_lat_long_delta, sleep, random_alt_delta
 
+
 class StepWalker(object):
 
-    def __init__(self, bot, dest_lat, dest_lng, dest_alt = None):
+    def __init__(self, bot, dest_lat, dest_lng, dest_alt=None, fixed_speed=False):
         self.bot = bot
         self.api = bot.api
 
@@ -22,7 +23,11 @@ class StepWalker(object):
             self.alt = uniform(self.bot.config.alt_min, self.bot.config.alt_max)
         else:
             self.alt = dest_alt
-        self.speed = uniform(self.bot.config.walk_min, self.bot.config.walk_max)
+        if not fixed_speed:
+            self.speed = uniform(self.bot.config.walk_min, self.bot.config.walk_max)
+        else:
+            # PolylineWalker uses a fixed speed!
+            self.speed = self.bot.config.walk_min
 
         if len(self.bot.position) == 3:
             self.initAlt = self.bot.position[2]


### PR DESCRIPTION
Related to https://github.com/PokemonGoF/PokemonGo-Bot/pull/5038

Fixes:

- we no longer override the super .step()
- make sure we don't invalidate the cache when StepWalker modifies a bit the values of lat, lng
- polyline does not round anymore (StepWalker would handle this)
- modified polyline_generator test to reflect non-rounding