### PR TITLE
Fix Elevation API limit reached

### DIFF
--- a/pokemongo_bot/walkers/polyline_generator.py
+++ b/pokemongo_bot/walkers/polyline_generator.py
@@ -88,7 +88,7 @@ class Polyline(object):
         self.ELEVATION_URL = '{}{}&samples={}'.format(self.ELEVATION_API_URL,
                                                       self.polyline, self.elevation_samples)
         self.elevation_response = requests.get(self.ELEVATION_URL).json()
-        self.polyline_elevations = [x['elevation'] for x in self.elevation_response['results']]
+        self.polyline_elevations = [x['elevation'] for x in self.elevation_response['results']] or [None]
         self._timestamp = time.time()
         self.is_paused = False
         self._last_paused_timestamp = None

--- a/pokemongo_bot/walkers/polyline_walker.py
+++ b/pokemongo_bot/walkers/polyline_walker.py
@@ -1,3 +1,5 @@
+from random import uniform
+
 from pokemongo_bot.walkers.step_walker import StepWalker
 from polyline_generator import PolylineObjectHandler
 
@@ -13,6 +15,6 @@ class PolylineWalker(StepWalker):
                                                               (self.dest_lat, self.dest_lng),
                                                               self.speed)
         self.pol_lat, self.pol_lon = self.polyline.get_pos()
-        self.pol_alt = self.polyline.get_alt()
+        self.pol_alt = self.polyline.get_alt() or uniform(self.bot.config.alt_min, self.bot.config.alt_max)
         super(PolylineWalker, self).__init__(self.bot, self.pol_lat, self.pol_lon,
                                              self.pol_alt, fixed_speed=True)


### PR DESCRIPTION
empty list returned in Elevation API response when limit reached 

will return None which is handled in the PolylineWalker by uniform(self.bot.config.alt_min, self.bot.config.alt_max)